### PR TITLE
Fix Web ACL logs

### DIFF
--- a/firehose.tf
+++ b/firehose.tf
@@ -1,13 +1,10 @@
 locals {
   lifecycle_configuration_rules = [{
     enabled = true # bool
-    id      = "v2rule"
+    id      = "vrule"
 
     abort_incomplete_multipart_upload_days = 1 # number
-
-    expiration = {
-      days = 30 # integer > 0
-    }
+    expiration_days = 30
   }]
 }
 
@@ -24,23 +21,23 @@ module "firehose_label" {
 }
 
 module "firehose_s3_bucket" {
-  count                         = local.enabled && var.firehose_enabled ? 1 : 0
-  source                        = "cloudposse/s3-bucket/aws"
-  version                       = "0.48.0"
-  acl                           = "private"
-  enabled                       = true
-  user_enabled                  = true
-  versioning_enabled            = false
-  allowed_bucket_actions        = ["s3:GetObject", "s3:ListBucket", "s3:GetBucketLocation"]
-  name                          = module.firehose_label.id
-  stage                         = module.this.stage
-  namespace                     = module.this.namespace
-  bucket_name                   = module.firehose_label.id
-  s3_replication_enabled        = false
-  replication_rules             = []
-  s3_replication_rules          = []
-  lifecycle_configuration_rules = local.lifecycle_configuration_rules
-  policy                        = <<EOF
+  count                  = local.enabled && var.firehose_enabled ? 1 : 0
+  source                 = "cloudposse/s3-bucket/aws"
+  version                = "0.44.0"
+  acl                    = "private"
+  enabled                = true
+  user_enabled           = true
+  versioning_enabled     = false
+  allowed_bucket_actions = ["s3:GetObject", "s3:ListBucket", "s3:GetBucketLocation"]
+  name                   = module.firehose_label.id
+  stage                  = module.this.stage
+  namespace              = module.this.namespace
+  bucket_name            = module.firehose_label.id
+  s3_replication_enabled = false
+  replication_rules      = []
+  s3_replication_rules   = []
+  lifecycle_rules        = local.lifecycle_configuration_rules
+  policy                 = <<EOF
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -66,7 +63,7 @@ module "firehose_s3_bucket" {
     ]
 }
 EOF
-  context                       = module.this.context
+  context                = module.this.context
 }
 
 data "aws_iam_policy_document" "assume_role" {

--- a/firehose.tf
+++ b/firehose.tf
@@ -1,3 +1,35 @@
+locals {
+  lifecycle_configuration_rules = [{
+    enabled = true # bool
+    id      = "v2rule"
+
+    abort_incomplete_multipart_upload_days = 1 # number
+
+    filter_and = null
+    expiration = {
+      days = 30 # integer > 0
+    }
+    noncurrent_version_expiration = {
+      newer_noncurrent_versions = 3  # integer > 0
+      noncurrent_days           = 60 # integer >= 0
+    }
+    transition = [{
+      days          = 30            # integer >= 0
+      storage_class = "STANDARD_IA" # string/enum, one of GLACIER, STANDARD_IA, ONEZONE_IA, INTELLIGENT_TIERING, DEEP_ARCHIVE, GLACIER_IR.
+      },
+      {
+        days          = 60           # integer >= 0
+        storage_class = "ONEZONE_IA" # string/enum, one of GLACIER, STANDARD_IA, ONEZONE_IA, INTELLIGENT_TIERING, DEEP_ARCHIVE, GLACIER_IR.
+    }]
+    noncurrent_version_transition = [{
+      newer_noncurrent_versions = 3            # integer >= 0
+      noncurrent_days           = 30           # integer >= 0
+      storage_class             = "ONEZONE_IA" # string/enum, one of GLACIER, STANDARD_IA, ONEZONE_IA, INTELLIGENT_TIERING, DEEP_ARCHIVE, GLACIER_IR.
+    }]
+  }]
+}
+
+
 data "aws_organizations_organization" "organization" {}
 
 module "firehose_label" {
@@ -10,22 +42,23 @@ module "firehose_label" {
 }
 
 module "firehose_s3_bucket" {
-  count                  = local.enabled && var.firehose_enabled ? 1 : 0
-  source                 = "cloudposse/s3-bucket/aws"
-  version                = "0.44.0"
-  acl                    = "private"
-  enabled                = true
-  user_enabled           = true
-  versioning_enabled     = false
-  allowed_bucket_actions = ["s3:GetObject", "s3:ListBucket", "s3:GetBucketLocation"]
-  name                   = module.firehose_label.id
-  stage                  = module.this.stage
-  namespace              = module.this.namespace
-  bucket_name            = module.firehose_label.id
-  s3_replication_enabled = false
-  replication_rules      = []
-  s3_replication_rules   = []
-  policy = <<EOF
+  count                         = local.enabled && var.firehose_enabled ? 1 : 0
+  source                        = "cloudposse/s3-bucket/aws"
+  version                       = "0.44.0"
+  acl                           = "private"
+  enabled                       = true
+  user_enabled                  = true
+  versioning_enabled            = false
+  allowed_bucket_actions        = ["s3:GetObject", "s3:ListBucket", "s3:GetBucketLocation"]
+  name                          = module.firehose_label.id
+  stage                         = module.this.stage
+  namespace                     = module.this.namespace
+  bucket_name                   = module.firehose_label.id
+  s3_replication_enabled        = false
+  replication_rules             = []
+  s3_replication_rules          = []
+  lifecycle_configuration_rules = local.lifecycle_configuration_rules
+  policy                        = <<EOF
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -51,7 +84,7 @@ module "firehose_s3_bucket" {
     ]
 }
 EOF
-  context = module.this.context
+  context                       = module.this.context
 }
 
 data "aws_iam_policy_document" "assume_role" {

--- a/firehose.tf
+++ b/firehose.tf
@@ -1,14 +1,27 @@
 locals {
   lifecycle_configuration_rules = [{
-    enabled                                = true # bool
-    abort_incomplete_multipart_upload_days = 1    # number
-    expiration_days                        = 30
-    tags = {
-      terraform = true
-    }
+    enabled                  = true
+    prefix                   = ""
+    standard_transition_days = 30
+    tags                     = { terraform = true }
+
+    abort_incomplete_multipart_upload_days = 1
+    deeparchive_transition_days            = 90
+
+    enable_current_object_expiration     = true
+    enable_deeparchive_transition        = false
+    enable_glacier_transition            = false
+    enable_noncurrent_version_expiration = true
+    enable_standard_ia_transition        = false
+
+    expiration_days         = 21
+    glacier_transition_days = 60
+
+    noncurrent_version_deeparchive_transition_days = 60
+    noncurrent_version_expiration_days             = 90
+    noncurrent_version_glacier_transition_days     = 30
   }]
 }
-
 
 data "aws_organizations_organization" "organization" {}
 

--- a/firehose.tf
+++ b/firehose.tf
@@ -5,27 +5,9 @@ locals {
 
     abort_incomplete_multipart_upload_days = 1 # number
 
-    filter_and = null
     expiration = {
       days = 30 # integer > 0
     }
-    noncurrent_version_expiration = {
-      newer_noncurrent_versions = 3  # integer > 0
-      noncurrent_days           = 60 # integer >= 0
-    }
-    transition = [{
-      days          = 30            # integer >= 0
-      storage_class = "STANDARD_IA" # string/enum, one of GLACIER, STANDARD_IA, ONEZONE_IA, INTELLIGENT_TIERING, DEEP_ARCHIVE, GLACIER_IR.
-      },
-      {
-        days          = 60           # integer >= 0
-        storage_class = "ONEZONE_IA" # string/enum, one of GLACIER, STANDARD_IA, ONEZONE_IA, INTELLIGENT_TIERING, DEEP_ARCHIVE, GLACIER_IR.
-    }]
-    noncurrent_version_transition = [{
-      newer_noncurrent_versions = 3            # integer >= 0
-      noncurrent_days           = 30           # integer >= 0
-      storage_class             = "ONEZONE_IA" # string/enum, one of GLACIER, STANDARD_IA, ONEZONE_IA, INTELLIGENT_TIERING, DEEP_ARCHIVE, GLACIER_IR.
-    }]
   }]
 }
 

--- a/firehose.tf
+++ b/firehose.tf
@@ -1,8 +1,6 @@
 locals {
   lifecycle_configuration_rules = [{
     enabled = true # bool
-    id      = "vrule"
-
     abort_incomplete_multipart_upload_days = 1 # number
     expiration_days = 30
   }]

--- a/firehose.tf
+++ b/firehose.tf
@@ -10,7 +10,7 @@ module "firehose_label" {
 module "firehose_s3_bucket" {
   count                  = local.enabled && var.firehose_enabled ? 1 : 0
   source                 = "cloudposse/s3-bucket/aws"
-  version                = "0.49.0"
+  version                = "0.44.0"
   acl                    = "private"
   enabled                = true
   user_enabled           = true
@@ -23,31 +23,7 @@ module "firehose_s3_bucket" {
   s3_replication_enabled = false
   replication_rules      = []
   s3_replication_rules   = []
-  policy                 = data.aws_iam_policy_document.web_acl_organization_shared_logs.json
-
-  context = module.this.context
-}
-
-data "aws_iam_policy_document" "assume_role" {
-  count = local.enabled ? 1 : 0
-
-  statement {
-    effect  = "Allow"
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      type        = "Service"
-      identifiers = ["firehose.amazonaws.com"]
-    }
-  }
-}
-
-data "aws_organizations_organization" "organization" {}
-data "aws_iam_policy_document" "web_acl_organization_shared_logs" {
-  name   = "WebAClPutObject"
   policy = <<EOF
-{
-  "Version": "2012-10-17",
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -73,7 +49,24 @@ data "aws_iam_policy_document" "web_acl_organization_shared_logs" {
     ]
 }
 EOF
+  context = module.this.context
 }
+
+data "aws_iam_policy_document" "assume_role" {
+  count = local.enabled ? 1 : 0
+
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["firehose.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_organizations_organization" "organization" {}
 
 resource "aws_iam_role" "firehose_role" {
   count = local.enabled && var.firehose_enabled ? 1 : 0

--- a/firehose.tf
+++ b/firehose.tf
@@ -26,7 +26,7 @@ module "firehose_label" {
 module "firehose_s3_bucket" {
   count                         = local.enabled && var.firehose_enabled ? 1 : 0
   source                        = "cloudposse/s3-bucket/aws"
-  version                       = "0.44.0"
+  version                       = "0.48.0"
   acl                           = "private"
   enabled                       = true
   user_enabled                  = true

--- a/firehose.tf
+++ b/firehose.tf
@@ -1,8 +1,11 @@
 locals {
   lifecycle_configuration_rules = [{
-    enabled = true # bool
-    abort_incomplete_multipart_upload_days = 1 # number
-    expiration_days = 30
+    enabled                                = true # bool
+    abort_incomplete_multipart_upload_days = 1    # number
+    expiration_days                        = 30
+    tags = {
+      terraform = true
+    }
   }]
 }
 

--- a/firehose.tf
+++ b/firehose.tf
@@ -1,3 +1,5 @@
+data "aws_organizations_organization" "organization" {}
+
 module "firehose_label" {
   source  = "cloudposse/label/null"
   version = "0.24.1"
@@ -65,8 +67,6 @@ data "aws_iam_policy_document" "assume_role" {
     }
   }
 }
-
-data "aws_organizations_organization" "organization" {}
 
 resource "aws_iam_role" "firehose_role" {
   count = local.enabled && var.firehose_enabled ? 1 : 0


### PR DESCRIPTION
- Bucket Policy to write WAF Web ACL logs to shared S3 bucket
- FIX
-  Error: Unsupported Terraform Core version
│ 
│   on .terraform/modules/fms.firehose_s3_bucket/versions.tf line 2, in terraform:
│    2:   required_version = ">= 1.0"


## what
* Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
* Use bullet points to be concise and to the point.

## why
* Provide the justifications for the changes (e.g. business case). 
* Describe why these changes were made (e.g. why do these commits fix the problem?)
* Use bullet points to be concise and to the point.

## references
* Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
* Use `closes #123`, if this PR closes a GitHub issue `#123`

