### PR TITLE
Adding support to Automatic Response for Shield

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -160,6 +160,15 @@ variable "shield_advanced_policies" {
       A list of AWS Organization member Accounts that you want to exclude from this AWS FMS Policy.
     include_account_ids:
       A list of AWS Organization member Accounts that you want to include for this AWS FMS Policy.
+    policy_data: # Should be used for CloudFront only. (ALBs are not supported yet)
+      automaticResponseStatus:
+        The default value for automaticResponseStatus is IGNORED
+        Possible values: `ENABLED`, `IGNORED`, or `DISABLED`.
+      automaticResponseAction:
+        The value for automaticResponseAction is only required when automaticResponseStatus is set to ENABLED.
+        Possible values: `BLOCK` or `COUNT`.
+      overrideCustomerWebaclClassic:
+        The default value for overrideCustomerWebaclClassic is false
   DOC
 }
 


### PR DESCRIPTION
## what
* Adding Support to Automatic Response for AWS Shield Advanced

## why
* We want to add full automation to the Firewall Manager / WAFv2 / Shield this is going towards this target. 

## references
* Unfortunately AWS doesn't support it for ALBs yet [Link](https://docs.aws.amazon.com/fms/2018-01-01/APIReference/API_SecurityServicePolicyData.html#:~:text=Specification%20for%20SHIELD_ADVANCED%20for%20Amazon%20CloudFront%20distributions)

